### PR TITLE
Feature: Allow streaming to a local IP

### DIFF
--- a/server/helpers/ip-addresses.ts
+++ b/server/helpers/ip-addresses.ts
@@ -1,0 +1,27 @@
+export function ipToInt(ip: string) {
+	return (
+		ip
+			.split(".")
+			.reduce((acc, octet) => (acc << 8) + Number.parseInt(octet, 10), 0) >>> 0
+	);
+}
+
+export function isSameSubnet(ip1: string, ip2: string, netmask: string) {
+	const ip1Int = ipToInt(ip1);
+	const ip2Int = ipToInt(ip2);
+	const netmaskInt = ipToInt(netmask);
+
+	return (ip1Int & netmaskInt) === (ip2Int & netmaskInt);
+}
+
+const localIpPatterns = [
+	/^127\./, // Loopback addresses
+	/^10\./, // Class A private addresses
+	/^192\.168\./, // Class C private addresses
+	/^172\.(1[6-9]|2\d|3[0-1])\./, // Class B private addresses (172.16.0.0 - 172.31.255.255)
+	/^169\.254\./, // Link-local addresses
+];
+
+export function isLocalIp(ip: string) {
+	return localIpPatterns.some((pattern) => pattern.test(ip));
+}

--- a/server/modules/network/moblink-relay.ts
+++ b/server/modules/network/moblink-relay.ts
@@ -5,11 +5,15 @@ import { checkExecPath, checkExecPathSafe } from "../../helpers/exec.ts";
 import { logger } from "../../helpers/logger.ts";
 import { stableUuidFromString } from "../../helpers/uuid.ts";
 import { setup } from "../setup.ts";
-import { getNetworkInterfaces } from "./network-interfaces.ts";
+import {
+	getNetworkInterfaces,
+	onNetworkInterfacesChange,
+} from "./network-interfaces.ts";
 
 const enabled = setup.moblink_relay_enabled;
 
-const RELAY_COOLDOWN = 5_000;
+const RELAY_COOLDOWN = 3_000;
+const INTERFACES_UPDATE_RATE = 10_000;
 
 export const moblinkRelayExec =
 	setup.moblink_relay_bin ??
@@ -114,7 +118,8 @@ export function initMoblinkRelays() {
 		return;
 	}
 
-	setInterval(updateMoblinkRelayInterfaces, 60_000);
+	setInterval(updateMoblinkRelayInterfaces, INTERFACES_UPDATE_RATE);
+	onNetworkInterfacesChange(updateMoblinkRelayInterfaces);
 }
 
 function findDestinationInterfaces() {

--- a/server/modules/wifi/wifi-interfaces.ts
+++ b/server/modules/wifi/wifi-interfaces.ts
@@ -23,6 +23,7 @@ import {
 	NETIF_ERR_HOTSPOT,
 	getNetworkInterfaces,
 	setNetifHotspot,
+	triggerNetworkInterfacesChange,
 } from "../network/network-interfaces.ts";
 import {
 	type ConnectionUUID,
@@ -31,7 +32,7 @@ import {
 	nmDevices,
 	nmcliParseSep,
 } from "../network/network-manager.ts";
-import { updateSrtlaIps } from "../streaming/srtla.ts";
+
 import {
 	addWifiInterface,
 	getWifiInterfaceByMacAddress,
@@ -230,7 +231,7 @@ export async function wifiUpdateDevices() {
 		}
 
 		if (hotspotCount) {
-			updateSrtlaIps();
+			triggerNetworkInterfacesChange();
 		}
 	}
 	logger.debug("Wifi interfaces", wifiInterfacesByMacAddress);

--- a/server/tests/is-local-ip.test.ts
+++ b/server/tests/is-local-ip.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { isLocalIp } from "../helpers/ip-addresses.ts"; // Adjust the import path if necessary
+
+describe("isLocalIp", () => {
+	it("should return true for loopback addresses", () => {
+		expect(isLocalIp("127.0.0.1")).toBe(true);
+		expect(isLocalIp("127.255.255.255")).toBe(true);
+	});
+
+	it("should return true for private class A addresses", () => {
+		expect(isLocalIp("10.0.0.1")).toBe(true);
+		expect(isLocalIp("10.255.255.255")).toBe(true);
+	});
+
+	it("should return true for private class B addresses", () => {
+		expect(isLocalIp("172.16.0.1")).toBe(true);
+		expect(isLocalIp("172.31.255.255")).toBe(true);
+		expect(isLocalIp("172.15.255.255")).toBe(false); // Outside the private range
+		expect(isLocalIp("172.32.0.0")).toBe(false); // Outside the private range
+	});
+
+	it("should return true for private class C addresses", () => {
+		expect(isLocalIp("192.168.1.1")).toBe(true);
+		expect(isLocalIp("192.168.255.255")).toBe(true);
+	});
+
+	it("should return true for link-local addresses", () => {
+		expect(isLocalIp("169.254.1.1")).toBe(true);
+	});
+
+	it("should return false for public addresses", () => {
+		expect(isLocalIp("8.8.8.8")).toBe(false);
+		expect(isLocalIp("1.1.1.1")).toBe(false);
+		expect(isLocalIp("192.169.1.1")).toBe(false); // Similar but not private
+		expect(isLocalIp("172.33.0.1")).toBe(false); // Outside the private range
+	});
+
+	it("should return false for invalid IPs", () => {
+		expect(isLocalIp("999.999.999.999")).toBe(false);
+		expect(isLocalIp("not.an.ip")).toBe(false);
+		expect(isLocalIp("")).toBe(false);
+	});
+});

--- a/server/tests/is-same-subnet.test.ts
+++ b/server/tests/is-same-subnet.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { isSameSubnet } from "../helpers/ip-addresses";
+
+describe("isSameSubnet", () => {
+	it("should return true for IPs in the same /24 subnet", () => {
+		expect(isSameSubnet("192.168.1.1", "192.168.1.2", "255.255.255.0")).toBe(
+			true,
+		);
+		expect(
+			isSameSubnet("192.168.1.100", "192.168.1.200", "255.255.255.0"),
+		).toBe(true);
+	});
+
+	it("should return false for IPs in different /24 subnets", () => {
+		expect(isSameSubnet("192.168.1.1", "192.168.2.1", "255.255.255.0")).toBe(
+			false,
+		);
+		expect(isSameSubnet("10.0.0.1", "10.0.1.1", "255.255.255.0")).toBe(false);
+	});
+
+	it("should return true for IPs in the same /16 subnet", () => {
+		expect(isSameSubnet("192.168.1.1", "192.168.2.1", "255.255.0.0")).toBe(
+			true,
+		);
+		expect(isSameSubnet("10.0.1.1", "10.0.254.254", "255.255.0.0")).toBe(true);
+	});
+
+	it("should return false for IPs in different /16 subnets", () => {
+		expect(isSameSubnet("10.1.1.1", "10.2.1.1", "255.255.0.0")).toBe(false);
+	});
+
+	it("should return true for IPs in the same /8 subnet", () => {
+		expect(isSameSubnet("10.1.1.1", "10.2.2.2", "255.0.0.0")).toBe(true);
+		expect(isSameSubnet("10.255.255.255", "10.0.0.0", "255.0.0.0")).toBe(true);
+	});
+
+	it("should return false for completely different networks", () => {
+		expect(isSameSubnet("192.168.1.1", "10.0.0.1", "255.255.255.0")).toBe(
+			false,
+		);
+		expect(isSameSubnet("172.16.1.1", "8.8.8.8", "255.255.0.0")).toBe(false);
+	});
+
+	it("should handle edge cases", () => {
+		expect(isSameSubnet("0.0.0.0", "0.0.0.0", "255.255.255.255")).toBe(true);
+		expect(
+			isSameSubnet("255.255.255.255", "255.255.255.255", "255.255.255.255"),
+		).toBe(true);
+		expect(isSameSubnet("192.168.1.1", "192.168.1.2", "0.0.0.0")).toBe(true); // Any IP is in the same subnet with netmask 0.0.0.0
+	});
+});


### PR DESCRIPTION
This will check if the relay target (IP address) is a local address and will try to find the interface with a matching subnet. If one is found, it will set the list of srtla ip addresses to that of those local interfaces.

Use cases would be streaming to a local OBS or Moblin that is connected to a hotspot provided by the encoder or a connected device.

Resolves #4