### PR TITLE
Enhance deploy-to-local.sh error handling and use SSH_TARGET as param

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ pair: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on
 - Install the generated private ssh key on the host (e.g. `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`)
 - It might be necessary or recommended to install a newer version of rsync from brew or similar (not tested if
   necessary)
-- Run the deployment script (`./deploy-to-local.sh`), if necessary change the host or user (`SSH_TARGET`), e.g.
-  `SSH_TARGET=root@192.168.100.100`.
+- Run the deployment script by specifying the SSH target as an argument. For example, to deploy as root to a host at 192.168.100.100, run:
+
+```bash
+./deploy-to-local.sh root@192.168.100.100
+```
 
 ### Reset to default belaUI
 

--- a/deploy-to-local.sh
+++ b/deploy-to-local.sh
@@ -1,14 +1,31 @@
 #!/usr/bin/env bash
-
+# Usage: ./deploy-to-local.sh [SSH_TARGET]
+# If no SSH_TARGET is provided, it defaults to "root@belabox.local"
 # Deploy dist to local belabox via ssh (rsync) and register service and restart service
 
-SSH_TARGET=root@belabox.local
+# This script uses strict error handling:
+#   - set -e: Exit immediately if any command returns a non-zero status.
+#   - set -u: Treat unset variables as errors and exit immediately.
+#   - set -o pipefail: Ensure that a pipeline fails if any command in it fails.
+set -euo pipefail
+
+SSH_TARGET=${1:-root@belabox.local}
 DIST_PATH=dist
 BELAUI_PATH=/opt/belaUI
 RSYNC_TARGET="${SSH_TARGET}:${BELAUI_PATH}"
 
-# stop on error
-set -e
+# Function to check for a command and install it if missing.
+install_if_missing() {
+  local cmd=$1
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Command '$cmd' not found. Installing..."
+    sudo apt-get update && sudo apt-get install -y "$cmd"
+  fi
+}
+
+# Check required local commands individually.
+install_if_missing rsync
+install_if_missing jq
 
 echo "Deploying to $RSYNC_TARGET"
 rsync -rltvz --delete --chown=root:root \
@@ -19,10 +36,8 @@ rsync -rltvz --delete --chown=root:root \
   --exclude relays_cache.json \
   --exclude revision \
   --exclude setup.json \
-  "${DIST_PATH}/" $RSYNC_TARGET
+  "${DIST_PATH}/" "$RSYNC_TARGET"
 
-# Install jq if its not installed
-ssh "$SSH_TARGET" "jq --version 2>/dev/null || apt-get update && apt-get install -y jq"
 
 # Add moblink_relay_enabled: true to setup.json
 echo "Enabling Moblink Relay. You can disable it in $BELAUI_PATH/setup.json"
@@ -39,3 +54,5 @@ echo "Moblink relay installed successfully."
 
 # shellcheck disable=SC2029
 ssh "$SSH_TARGET" "cd $BELAUI_PATH; bash ./override-belaui.sh"
+
+echo "Deployment complete."

--- a/deploy-to-local.sh
+++ b/deploy-to-local.sh
@@ -14,18 +14,46 @@ DIST_PATH=dist
 BELAUI_PATH=/opt/belaUI
 RSYNC_TARGET="${SSH_TARGET}:${BELAUI_PATH}"
 
+# Detect OS and package manager
+detect_package_manager() {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "brew"
+  elif command -v apt-get >/dev/null 2>&1; then
+    echo "apt"
+  elif command -v pacman >/dev/null 2>&1; then
+    echo "pacman"
+  else
+    echo "unknown"
+  fi
+}
+
+PACKAGE_MANAGER=$(detect_package_manager)
+
 # Function to check for a command and install it if missing.
 install_if_missing() {
   local cmd=$1
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "Command '$cmd' not found. Installing..."
-    sudo apt-get update && sudo apt-get install -y "$cmd"
+    case "$PACKAGE_MANAGER" in
+      brew)
+        brew install "$cmd"
+        ;;
+      apt)
+        sudo apt-get update && sudo apt-get install -y "$cmd"
+        ;;
+      pacman)
+        sudo pacman -Sy --noconfirm "$cmd"
+        ;;
+      *)
+        echo "Unsupported package manager. Please install '$cmd' manually."
+        exit 1
+        ;;
+    esac
   fi
 }
 
-# Check required local commands individually.
+# Ensure rsync is installed
 install_if_missing rsync
-install_if_missing jq
 
 echo "Deploying to $RSYNC_TARGET"
 rsync -rltvz --delete --chown=root:root \
@@ -38,6 +66,8 @@ rsync -rltvz --delete --chown=root:root \
   --exclude setup.json \
   "${DIST_PATH}/" "$RSYNC_TARGET"
 
+# Install jq if its not installed
+ssh "$SSH_TARGET" "jq --version 2>/dev/null || apt-get update && apt-get install -y jq"
 
 # Add moblink_relay_enabled: true to setup.json
 echo "Enabling Moblink Relay. You can disable it in $BELAUI_PATH/setup.json"


### PR DESCRIPTION
- Upgrade error handling by replacing "set -e" with "set -euo pipefail".
- add inline checks to install rsync and jq,  if missing.
- add the possibility of passing SSH_TARGET as param for the script