### PR TITLE
add option to the installation scripts to allow using CeraUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,21 @@
 This is a fork of the default BELABOX UI (belaUI), that ported the code to Typescript and ESM (ECMAScript Modules) and
 added a moblink relay feature.
 
+## CeraUI Integration
+
+This fork includes an option to use the [CeraUI](https://github.com/CERALIVE/CeraUI) interface, which is an alternative user interface designed for enhanced usability and additional features. When the `USE_CERAUI` option is enabled during installation or deployment, the system will download the latest CeraUI [release](https://github.com/CERALIVE/CeraUI/releases/latest) and use it instead of the standard BelaUI interface.
+
 ## Install the fork on your BELABOX
 
 - Enable SSH for the default user (`user`) on your existing belaUI
 - Connect to the BELABOX via SSH (use Putty on Windows, JuiceSSH on Android)
 - Then run:
   ```bash
+  # Standard installation with BelaUI
   wget -qO- https://raw.githubusercontent.com/pjeweb/belaui/override/install.sh | bash
+  
+  # Installation with CeraUI interface
+  wget -qO- https://raw.githubusercontent.com/pjeweb/belaui/override/install.sh | USE_CERAUI=true bash
   ```
 - To get back to the default belaUI, you can then run `sudo bash /opt/belaUI/reset-to-default.sh` through SSH.
 
@@ -86,7 +94,11 @@ pair: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-on
 - Run the deployment script by specifying the SSH target as an argument. For example, to deploy as root to a host at 192.168.100.100, run:
 
 ```bash
+# Standard deployment with BelaUI
 ./deploy-to-local.sh root@192.168.100.100
+
+# Deployment with CeraUI interface
+USE_CERAUI=true ./deploy-to-local.sh root@192.168.100.100
 ```
 
 ### Reset to default belaUI

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,11 @@
 # Install script to install the belaUI fork on a BELABOX
 
 # Variables
+USE_CERAUI=${USE_CERAUI:-false}
 RELEASE_TARBALL="belaUI.tar.xz"
 RELEASE_URL="https://github.com/pjeweb/belaUI/releases/latest/download/$RELEASE_TARBALL"
+CERAUI_RELEASE_TARBALL="ceraui-extended.tar.xz"
+CERAUI_RELEASE_URL="https://github.com/CERALIVE/CeraUI/releases/latest/download/$CERAUI_RELEASE_TARBALL"
 TEMP_DIR="$HOME/.tmp/belaui"
 TARGET_DIR="/opt/belaUI"
 
@@ -74,5 +77,26 @@ cd $TARGET_DIR || exit
 sudo bash ./override-belaui.sh
 
 echo "BelaUI installed and override script executed successfully."
+
+# Check if CeraUI should be installed
+if [ "$USE_CERAUI" = "true" ]; then
+  echo "Downloading and installing CeraUI content"
+  # Create a temporary directory for CeraUI
+  CERAUI_TEMP_DIR="$HOME/.tmp/ceraui"
+  mkdir -p "$CERAUI_TEMP_DIR"
+  cd "$CERAUI_TEMP_DIR" || exit
+
+  # Download and extract CeraUI
+  wget -q --show-progress $CERAUI_RELEASE_URL
+  tar xf $CERAUI_RELEASE_TARBALL
+
+  # Replace the content of the public folder
+  sudo rsync -rltz --delete --chown=root:root "$CERAUI_TEMP_DIR/" "$TARGET_DIR/public/"
+
+  # Cleanup
+  rm -rf "$CERAUI_TEMP_DIR"
+
+  echo "CeraUI installed successfully."
+fi
 
 echo "You can reset to default by running: sudo $TARGET_DIR/reset-to-default.sh"


### PR DESCRIPTION
  1. Modified install.sh to accept a USE_CERAUI parameter
  2. Modified deploy-to-local.sh to support the same parameter
  3. Updated the README.md to document this new functionality
  4. Added checks to ensure required tools are available
  
  as a solution for https://github.com/pjeweb/belaUI/issues/33